### PR TITLE
update variables and number of instances

### DIFF
--- a/ci/import-test.yml
+++ b/ci/import-test.yml
@@ -8,5 +8,5 @@ run:
   path: deploy-defectdojo-config/ci/import-test.sh
 
 params:
-  DEFECTDOJO_IMPORT_URL: ((defectdojo_import_url))
-  DEFECTDOJO_AUTH_TOKEN: ((defectdojo_auth_token))
+  DEFECTDOJO_IMPORT_URL:
+  DEFECTDOJO_AUTH_TOKEN:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -192,12 +192,18 @@ jobs:
           - get: deploy-defectdojo-config
             passed: [deploy-defectdojo-staging]
             trigger: true
+          - get: defectdojo-release
+            passed: [deploy-defectdojo-staging]
+            trigger: true
           - get: general-task
           - get: hourly
             trigger: true
       - task: set-deduplication
         image: general-task
         file: deploy-defectdojo-config/ci/set-deduplication.yml
+        params:
+          DEFECTDOJO_SYSTEM_SETTINGS_URL: ((defectdojo_staging_system_settings_url))
+          DEFECTDOJO_AUTH_TOKEN: ((defectdojo_staging_auth_token))
 
     on_failure:
       put: slack
@@ -213,10 +219,16 @@ jobs:
           - get: deploy-defectdojo-config
             passed: [deploy-defectdojo-staging]
             trigger: true
+          - get: defectdojo-release
+            passed: [deploy-defectdojo-staging]
+            trigger: true
           - get: general-task
       - task: test-import
         image: general-task
         file: deploy-defectdojo-config/ci/import-test.yml
+        params:
+          DEFECTDOJO_IMPORT_URL: ((defectdojo_staging_import_url))
+          DEFECTDOJO_AUTH_TOKEN: ((defectdojo_staging_auth_token))
 
     on_failure:
       put: slack
@@ -235,7 +247,7 @@ jobs:
             passed:
               [
                 deploy-defectdojo-staging,
-                staging-deuplication,
+                staging-deduplication,
                 staging-test-import,
               ]
           - get: defectdojo-stemcell-jammy
@@ -315,6 +327,9 @@ jobs:
       - task: set-deduplication
         image: general-task
         file: deploy-defectdojo-config/ci/set-deduplication.yml
+        params:
+          DEFECTDOJO_SYSTEM_SETTINGS_URL: ((defectdojo_production_system_settings_url))
+          DEFECTDOJO_AUTH_TOKEN: ((defectdojo_production_auth_token))
 
     on_failure:
       put: slack
@@ -334,6 +349,9 @@ jobs:
       - task: test-import
         image: general-task
         file: deploy-defectdojo-config/ci/import-test.yml
+        params:
+          DEFECTDOJO_IMPORT_URL: ((defectdojo_production_import_url))
+          DEFECTDOJO_AUTH_TOKEN: ((defectdojo_production_auth_token))
 
     on_failure:
       put: slack

--- a/ci/set-deduplication.yml
+++ b/ci/set-deduplication.yml
@@ -8,5 +8,5 @@ run:
   path: deploy-defectdojo-config/ci/set-deduplication.sh
 
 params:
-  DEFECTDOJO_SYSTEM_SETTINGS_URL: ((defectdojo_system_settings_url))
-  DEFECTDOJO_AUTH_TOKEN: ((defectdojo_auth_token))
+  DEFECTDOJO_SYSTEM_SETTINGS_URL:
+  DEFECTDOJO_AUTH_TOKEN:

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,7 +21,7 @@ update:
 instance_groups:
   - name: defectdojo
     azs: [z1, z2]
-    instances: 1
+    instances: 2
     jobs:
       - name: bosh-dns-aliases
         properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add separate variables for staging and production urls and auth tokens
- Increase the number of instances to 2 for redundancy

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updating variables and adding redundancy
