### PR TITLE
allows setting number of instances

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -69,6 +69,7 @@ jobs:
           vars:
             nginx_server_name: ((development-nginx-server-name))
             deployment_name: ((development-deployment-name))
+            instances: ((development-instances))
             defectdojo_network: ((development-defectdojo-network))
             defectdojo_extension: ((development-defectdojo-extension))
             defectdojo_version: ((development-defectdojo-version))
@@ -133,6 +134,7 @@ jobs:
           vars:
             nginx_server_name: ((staging-nginx-server-name))
             deployment_name: ((staging-deployment-name))
+            instances: ((staging-instances))
             defectdojo_network: ((staging-defectdojo-network))
             defectdojo_extension: ((staging-defectdojo-extension))
             defectdojo_version: ((staging-defectdojo-version))
@@ -262,6 +264,7 @@ jobs:
           vars:
             nginx_server_name: ((production-nginx-server-name))
             deployment_name: ((production-deployment-name))
+            instances: ((production-instances))
             defectdojo_network: ((production-defectdojo-network))
             defectdojo_extension: ((production-defectdojo-extension))
             defectdojo_version: ((production-defectdojo-version))

--- a/manifest.yml
+++ b/manifest.yml
@@ -14,14 +14,14 @@ releases:
     version: latest
 
 update:
-  canaries: 2
+  canaries: 1
   max_in_flight: 1
   canary_watch_time: 5000-60000
   update_watch_time: 5000-60000
 instance_groups:
   - name: defectdojo
     azs: [z1, z2]
-    instances: 2
+    instances: ((instances))
     jobs:
       - name: bosh-dns-aliases
         properties:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds setting for instance count so it can be set per deployment
- Reduces canaries to 1

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Reducing number of resources being used
