### PR TITLE
Expand root disk to 10GB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -101,3 +101,4 @@ instance_groups:
       - name: ((defectdojo_network))
     vm_extensions:
       - ((defectdojo_extension))
+      - 10GB_root_disk


### PR DESCRIPTION
## Changes proposed in this pull request:

- Expand root disk to 10GB
- Part of https://github.com/cloud-gov/product/issues/2836
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, making disk bigger
