### PR TITLE
fix definition of self-setting pipeline job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,12 +1,5 @@
 ---
 jobs:
-  - name: set-self
-    plan:
-      - get: defectdojo-release-git-repo
-        trigger: true
-      - set_pipeline: self
-        file: defectdojo-release-git-repo/ci/pipeline.yml
-
   - name: build-defectdojo-release
     serial: true
     serial_groups: [development]
@@ -15,7 +8,6 @@ jobs:
           - get: release-git-repo
             resource: defectdojo-release-git-repo
             trigger: true
-            passed: [set-self]
           - get: pipeline-tasks
           - get: final-builds-dir-tarball
             resource: defectdojo-final-builds-dir-tarball
@@ -60,6 +52,13 @@ jobs:
         username: ((slack-username))
         icon_url: ((slack-icon-url))
 
+  - name: set-self
+    plan:
+      - get: deploy-defectdojo-config
+        trigger: true
+      - set_pipeline: self
+        file: deploy-defectdojo-config/ci/pipeline.yml
+
   - name: deploy-defectdojo-development
     serial: true
     serial_groups: [development]
@@ -68,6 +67,7 @@ jobs:
           - get: pipeline-tasks
           - get: deploy-defectdojo-config
             trigger: true
+            passed: [set-self]
           - get: defectdojo-release
             passed: [build-defectdojo-release]
             trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix for #16
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

No direct security considerations of these changes. In general, having pipeline variables managed in Credhub is more maintainable and will reduce risk of inadvertent updates to infrastructure